### PR TITLE
Drop privileges to reduce impact of an exploit.

### DIFF
--- a/src/spindump_main.c
+++ b/src/spindump_main.c
@@ -26,6 +26,8 @@
 #include <signal.h>
 #include <string.h>
 #include <ctype.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include "spindump_util.h"
 #include "spindump_capture.h"
 #include "spindump_analyze.h"
@@ -738,6 +740,10 @@ spindump_main_operation() {
   
   if (capturer == 0) exit(1);
 
+  if (setuid(getuid()) < 0) {
+	spindump_errorf("unable to drop root privileges");
+        exit(1);
+  }
   //
   // Initialize the user interface
   // 


### PR DESCRIPTION
running spindump as root is dangerous, as there is a lot of analyzer code also running as root. I would suggest the approach of chmod +4755 spindump, and this patch. OpenBSD does this already with ping/ping6, except that it's using setresuid() & setresguid().

Comments/feedback welcome. I'm also looking at push the capture interface code earlier so that root privileges can be dropped.
