### PR TITLE
Fix non-free'd memory issues

### DIFF
--- a/src/spindump_capture.c
+++ b/src/spindump_capture.c
@@ -53,7 +53,7 @@ spindump_capture_initialize_aux(const char* interface,
 // Return the name of the default interface in this system.
 //
 
-const char*
+char*
 spindump_capture_defaultinterface(void) {
 
   //

--- a/src/spindump_capture.h
+++ b/src/spindump_capture.h
@@ -58,7 +58,7 @@ struct spindump_capture_state {
 // Capture module API interface ---------------------------------------------------------------
 //
 
-const char*
+char*
 spindump_capture_defaultinterface(void);
 struct spindump_capture_state*
 spindump_capture_initialize_live(const char* interface,

--- a/src/spindump_main_lib.h
+++ b/src/spindump_main_lib.h
@@ -58,7 +58,7 @@ struct spindump_main_aggregate {
 };
 
 struct spindump_main_configuration {
-  const char* interface;
+  char* interface;
   const char* inputFile;
   char* filter;
   enum spindump_toolmode toolmode;

--- a/src/spindump_main_loop.c
+++ b/src/spindump_main_loop.c
@@ -79,11 +79,12 @@ spindump_main_loop_operation(struct spindump_main_state* state) {
   //
   // Initialize the actual operation
   //
-  
+  int interface_allocated = 0;
   struct spindump_main_configuration* config = &state->config;
   if (config->interface == 0 && config->inputFile == 0) {
     config->interface = spindump_capture_defaultinterface();
     if (config->interface == 0) exit(1);
+    interface_allocated = 1;
   }
 
   //
@@ -257,7 +258,10 @@ spindump_main_loop_operation(struct spindump_main_state* state) {
                                      config->anonymizeLeft,
                                      querier);
   }
-  
+  // Only free interface string if it was allocated by us
+  if (interface_allocated) {
+    spindump_free(config->interface);
+  }
   spindump_report_uninitialize(reporter);
   spindump_analyze_uninitialize(analyzer);
   spindump_capture_uninitialize(capturer);

--- a/src/spindump_test.c
+++ b/src/spindump_test.c
@@ -536,6 +536,8 @@ unittests_jsonvalue(void) {
   spindump_json_value_free(copy3);
   spindump_deepdebugf("copy4 free");
   spindump_json_value_free(copy4);
+  spindump_deepdebugf("string4 free");
+  spindump_free(string4);
 }
 
 //


### PR DESCRIPTION
Fixed two cases where memory was not freed correctly. One was in
test cases and other one was the value returned by
spindump_capture_defaultinterface(). However, the function return
type was specified to be const char*, which can't be free'd without
type casts or compiler warnings. Therefore, in order to allow memory
to be freed, changed the return type of the function to char*.