### PR TITLE
Fix compilation error on Ubuntu 20.04 (enum conversion)

### DIFF
--- a/src/spindump_main_lib.c
+++ b/src/spindump_main_lib.c
@@ -593,7 +593,7 @@ spindump_main_processargs(int argc,
       // group). Get the second of the two arguments
       //
 
-      enum {network, host, multinet} side2type = network;
+      enum side_type side2type = network;
       spindump_address side2address;
       spindump_network side2network;
       struct spindump_main_network_entry *side2networks = NULL;

--- a/src/spindump_main_lib.h
+++ b/src/spindump_main_lib.h
@@ -44,6 +44,12 @@ enum spindump_toolmode {
   spindump_toolmode_visual
 };
 
+enum side_type {
+  network,
+  host,
+  multinet
+};
+
 //
 // Data structures ----------------------------------------------------------------------------
 //
@@ -57,7 +63,7 @@ struct spindump_main_aggregate {
   int defaultMatch;
   int ismulticastgroup;
   int side1ishost;
-  enum {network, host, multinet} side2type;
+  enum side_type side2type;
   spindump_tags tags;
   uint8_t padding[4]; // unused padding to align the next field properly
   spindump_address side1address;


### PR DESCRIPTION
When I tried to compile it on Ubuntu 20.04 (GCC 10) I got the following error:

```
spyff@hp:~/Dokumentumok/spindump$ make
[ 86%] Built target spindumplib
[ 89%] Built target spindump_test
[ 90%] Building C object src/CMakeFiles/spindump.dir/spindump_main_lib.c.o
/home/spyff/Dokumentumok/spindump/src/spindump_main_lib.c: In function ‘spindump_main_processargs’:
/home/spyff/Dokumentumok/spindump/src/spindump_main_lib.c:674:28: error: implicit conversion from ‘enum <anonymous>’ to ‘enum <anonymous>’ [-Werror=enum-conversion]
  674 |       aggregate->side2type = side2type;
      |                            ^
/home/spyff/Dokumentumok/spindump/src/spindump_main_lib.c: At top level:
cc1: note: unrecognized command-line option ‘-Wno-documentation’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-reserved-id-macro’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-documentation-deprecated-sync’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-disabled-macro-expansion’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-covered-switch-default’ may have been intended to silence earlier diagnostics
cc1: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/spindump.dir/build.make:92: src/CMakeFiles/spindump.dir/spindump_main_lib.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:588: src/CMakeFiles/spindump.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

I fixed it with an introduction of an enum name. Maybe not too descriptive, but I can rename it to anything else.