### PR TITLE
Fixed MacOS build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,10 @@ add_library(spindumplib
 target_include_directories(spindumplib
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${MICROHTTPD_INCLUDE_DIR}
 )
+
+set_target_properties(spindumplib PROPERTIES COMPILE_FLAGS "-Wno-atomic-implicit-seq-cst")
 
 target_link_libraries(spindumplib
   PRIVATE
@@ -132,6 +135,7 @@ target_link_libraries(spindumplib
 
 add_executable(spindump spindump_main.c spindump_main_lib.c spindump_main_loop.c)
 target_link_libraries(spindump spindumplib)
+target_include_directories(spindump PRIVATE ${MICROHTTPD_INCLUDE_DIR})
 
 #
 # Testing


### PR DESCRIPTION
Fixed some errors on MacOS:

1. microhttpd.h not found
2. incompatible pointer types passing 'int (void *,...)` instead of `enum MHD_Result (void *, ...)`.
3. Disabled error "implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary [-Werror,-Watomic-implicit-seq-cst]"